### PR TITLE
Use `std::forward_list` instead of `std::vector`

### DIFF
--- a/src/dff.cpp
+++ b/src/dff.cpp
@@ -5,11 +5,37 @@
 #include "include/sha256.hpp"
 
 using pr::dff;
+using pr::Record;
+
+Record::Record(Record &&rec)
+    : m_size(rec.m_size), m_files(std::move(rec.m_files))
+{
+  rec.m_size = 0;
+  rec.m_files.clear();
+}
+
+auto Record::size() const -> std::size_t { return m_size; }
+
+void Record::insert(fs::path path)
+{
+  m_files.push_front(path);
+  ++m_size;
+}
+
+auto Record::begin() const -> std::forward_list<fs::path>::const_iterator
+{
+  return m_files.cbegin();
+}
+
+auto Record::end() const -> std::forward_list<fs::path>::const_iterator
+{
+  return m_files.cend();
+}
 
 dff::dff(const char *rootdir, bool follow_symlinks)
     : m_rootdir(rootdir), m_follow_symlinks(follow_symlinks) {}
 
-bool dff::find_dups() noexcept
+auto dff::find_dups() noexcept -> bool
 {
   try {
     auto rd_itr =
@@ -22,7 +48,7 @@ bool dff::find_dups() noexcept
               << "scanning directory: " << fs::canonical(m_rootdir)
               << "\x1b[m\n\n";
 
-    for (const auto &dirent: rd_itr) {
+    for (const auto &dirent : rd_itr) {
       if (!dirent.is_regular_file() || dirent.file_size() == 0)
         continue;
 
@@ -30,16 +56,24 @@ bool dff::find_dups() noexcept
       if (!opt_hash.has_value())
         continue;
 
-      auto [itr, inserted] = m_store.insert({opt_hash.value(), {dirent.path()}});
-      if (!inserted)
-        itr->second.push_back(dirent.path());
+      auto itr = m_store.find(opt_hash.value());
+
+      if (itr != m_store.end()) {
+        itr->second.insert(dirent.path());
+      } else {
+        Record rec;
+        rec.insert(dirent.path());
+        m_store.insert({opt_hash.value(), std::move(rec)});
+      }
     }
 
   } catch (const fs::filesystem_error &err) {
     std::cerr << "\x1b[31m" << err.what() << "\x1b[m\n";
     return false;
   } catch (...) {
-    std::cerr << "\x1b[31m" << "Error: some error occured" << "\x1b[m\n";
+    std::cerr << "\x1b[31m"
+              << "Error: some error occured"
+              << "\x1b[m\n";
     return false;
   }
   // true if no error occured.
@@ -48,11 +82,10 @@ bool dff::find_dups() noexcept
 
 void dff::print_dups() noexcept
 {
-  for (const auto &[_, paths] : m_store) {
-    if (paths.size() > 1) {
+  for (const auto &[_, rec] : m_store) {
+    if (rec.size() > 1) {
       std::cout << "\n\x1b[33m";
-      for (const auto &path : paths)
-        std::cout << path.c_str() << '\n';
+      for (const auto& path: rec) std::cout << path << '\n';
       std::cout << "\x1b[m\n";
     }
   }

--- a/src/include/dff.hpp
+++ b/src/include/dff.hpp
@@ -1,14 +1,31 @@
 #pragma once
 
 #include <filesystem>
+#include <forward_list>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 namespace pr {
 
+class Record;
+class dff;
+
 namespace fs = std::filesystem;
-using Store = std::unordered_map<std::string, std::vector<fs::path>>;
+using Store = std::unordered_map<std::string, Record>;
+
+class Record {
+public:
+  Record() = default;
+  Record(Record &&rec);
+  auto size() const -> std::size_t;
+  void insert(fs::path path);
+  auto begin() const -> std::forward_list<fs::path>::const_iterator;
+  auto end() const -> std::forward_list<fs::path>::const_iterator;
+
+private:
+  std::size_t m_size = 0;
+  std::forward_list<fs::path> m_files;
+};
 
 class dff {
 public:


### PR DESCRIPTION
Maintains lists of duplicate files using `std::forward_list` instead of `std::vector`. Adds newly found duplicate file, using the `push_front` function on the list. 